### PR TITLE
Use genome_build column of de_gpl_info table to store genome build relea...

### DIFF
--- a/Postgres/GPL 1.0/VCF/generate_VCF_loading_files.pl
+++ b/Postgres/GPL 1.0/VCF/generate_VCF_loading_files.pl
@@ -54,7 +54,7 @@ our $het = 0;
 
 # Create a platform for VCF, if it doesn't exist yet
 open PLATFORM, "> load_platform.ctl" or die "Cannot open file: $!";
-print PLATFORM "insert into deapp.de_gpl_info (platform, title, marker_type, release_nbr)";
+print PLATFORM "insert into deapp.de_gpl_info (platform, title, marker_type, genome_build)";
 print PLATFORM "select '$gpl_id', 'VCF platform for $genome', 'VCF', '$genome' WHERE NOT EXISTS( ";
 print PLATFORM "  select platform from deapp.de_gpl_info where platform = '$gpl_id'";
 print PLATFORM ");";


### PR DESCRIPTION
...se identifiers

@forus 
The modifications in this pull request address the issue (https://jira.ctmmtrait.nl/browse/FT-1292) of the de_gpl_info table containing two columns which are associated with a genome build/release number and therefore the confusion about which field to map to the genomeReleaseId property in the core-api. Also the confusion which database field should be filled during the upload of molecular data is addressed. With the proposed modification the genome_build field in the de_gpl_info table will be mapped to the genomeReleaseId property in the core-api. The molecular data upload pipelines which support that genome build number are registered, are modified such that this information is stored in the right field (genome_build) in de_gpl_info. The release_nbr field is with these modifications not used for storing a genome build number anymore.